### PR TITLE
Use conda for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 install:
     - git submodule update --init --recursive
     - make
-    - pip install --user .
+    - pip install .
 
 script:
     # travis issue for osx, some libraries are build for x86_64 and others for i386.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,11 @@ before_install:
     - conda update -q conda
     # Useful for debugging any issues with conda
     - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cython numpy pandas scipy scikit-learn
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cython numpy pandas scipy scikit-learn nose
     - source activate test-environment
 
 install:
     - git submodule update --init --recursive
-    - pip install --user -r requirements.txt
-    - pip install --user nose
     - make
     - pip install --user .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 os:
     - linux
-    #- osx
+    - osx
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: python
+language: c
 
-python:
-    - "2.7"
+env:
+    - TRAVIS_PYTHON_VERSION="2.7"
 
 os:
     - linux
@@ -17,10 +17,18 @@ before_install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libblas-dev liblapack-dev gfortran; fi
       # fastFM-core dependencies
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y python-dev libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    - if [[ "$TRAVIS_PYTHON_VERSION" =~ "^2" ]]; then
+        if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        fi
       else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        fi
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ dist: trusty
 
 before_install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install python glib argp-standalone; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib argp-standalone; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq;  fi
       # needed to install scipy
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libblas-dev liblapack-dev gfortran; fi
       # fastFM-core dependencies
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y python-dev libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" =~ "^2" ]]; then
         if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,4 @@ install:
     - pip install .
 
 script:
-    # travis issue for osx, some libraries are build for x86_64 and others for i386.
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then nosetests; fi
+    - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-language: c
+language: python
 
 python:
     - "2.7"
 
 os:
     - linux
-    - osx
+    #- osx
 
 dist: trusty
 
@@ -17,6 +17,20 @@ before_install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libblas-dev liblapack-dev gfortran; fi
       # fastFM-core dependencies
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y python-dev libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    # Useful for debugging any issues with conda
+    - conda info -a
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cython numpy pandas scipy scikit-learn
+    - source activate test-environment
 
 install:
     - git submodule update --init --recursive


### PR DESCRIPTION
In order to speed up CI, I propose to use [Miniconda](http://conda.pydata.org/docs/travis.html).
Using Miniconda we can execute CI within [2 minitues](https://travis-ci.org/chezou/fastFM/builds/100968206).