### PR TITLE
remove unused system_links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ dist: trusty
 
 before_install:
       # fastFM-core depends on cblas
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libatlas-base-dev; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libopenblas-dev; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" =~ "^2" ]]; then
         if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,8 @@ Installation
 .. code-block:: bash
 
     # Install cblas and python-dev header (Linux only).
-    $ sudo apt-get install python-dev libatlas-base-dev
+    # - cblas can be installed with libatlas-base-dev or libopenblas-dev (Ubuntu)
+    $ sudo apt-get install python-dev libopenblas-dev
 
     # Clone the repro including submodules (or clone + `git submodule update --init --recursive`)
     $ git clone --recursive https://github.com/ibayer/fastFM.git

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,18 @@ from Cython.Distutils import build_ext
 import numpy
 
 ext_modules = [
-    Extension('ffm',
-        ['fastFM/ffm.pyx'],
-        libraries=['m', 'fastfm', 'cxsparse', 'cblas'],
-        library_dirs=['fastFM/', 'fastFM-core/bin/', 'fastFM-core/externals/CXSparse/Lib/',
-            '/usr/lib/','/usr/lib/atlas-base/'],
-        include_dirs=['fastFM/','fastFM-core/include/', 'fastFM-core/externals/CXSparse/Include/',
-            '/usr/include/',
-        numpy.get_include()])]
+    Extension('ffm', ['fastFM/ffm.pyx'],
+              libraries=['m', 'fastfm', 'cxsparse', 'cblas'],
+              library_dirs=['fastFM/', 'fastFM-core/bin/',
+                            'fastFM-core/externals/CXSparse/Lib/'],
+              include_dirs=['fastFM/', 'fastFM-core/include/',
+                            'fastFM-core/externals/CXSparse/Include/',
+              numpy.get_include()])]
 
 setup(
-    name = 'fastFM',
-    cmdclass = {'build_ext': build_ext},
-    ext_modules = ext_modules,
+    name='fastFM',
+    cmdclass={'build_ext': build_ext},
+    ext_modules=ext_modules,
 
     packages=['fastFM'],
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import numpy
 
 ext_modules = [
     Extension('ffm', ['fastFM/ffm.pyx'],
-              libraries=['m', 'fastfm', 'cxsparse', 'cblas'],
+              libraries=['m', 'fastfm', 'cxsparse', 'blas'],
               library_dirs=['fastFM/', 'fastFM-core/bin/',
                             'fastFM-core/externals/CXSparse/Lib/'],
               include_dirs=['fastFM/', 'fastFM-core/include/',


### PR DESCRIPTION
This PR  removes absolute paths in ``setup.py`` and links agains a generic blas version.
fastFM can now use any installed BLAS version e.g. ``openBLAS`` /  ``ATLAS``.
closes https://github.com/ibayer/fastFM/issues/41