### PR TITLE
[MRG] PEP8

### DIFF
--- a/fastFM/mcmc.py
+++ b/fastFM/mcmc.py
@@ -5,7 +5,6 @@
 import ffm
 import numpy as np
 from sklearn.metrics import mean_squared_error
-from sklearn.utils import assert_all_finite
 from .validation import (assert_all_finite, check_consistent_length,
                          check_array)
 from .base import (FactorizationMachine, _validate_class_labels,

--- a/fastFM/mcmc.py
+++ b/fastFM/mcmc.py
@@ -9,7 +9,7 @@ from sklearn.utils import assert_all_finite
 from .validation import (assert_all_finite, check_consistent_length,
                          check_array)
 from .base import (FactorizationMachine, _validate_class_labels,
-                  _check_warm_start)
+                   _check_warm_start)
 
 
 def find_init_stdev(fm, X_train, y_train, X_vali=None, y_vali=None,

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -5,7 +5,6 @@ import numpy as np
 import scipy.sparse as sp
 from sklearn import metrics
 from fastFM import als
-from numpy.testing import assert_almost_equal
 from fastFM.datasets import make_user_item_regression
 from sklearn.metrics import mean_squared_error
 from sklearn.utils.testing import assert_almost_equal

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -76,22 +76,22 @@ def test_fm_regression():
     assert_almost_equal(y_pred, y, 3)
     # check different size
     fm = als.FMRegression(n_iter=1000, l2_reg_w=0, l2_reg_V=0, rank=5)
-    X_big = sp.hstack([X,X])
+    X_big = sp.hstack([X, X])
     fm.fit(X_big, y)
-    y_pred = fm.predict(X_big[:2,])
+    y_pred = fm.predict(X_big[:2, ])
 
 
 def test_fm_classification():
     w0, w, V, y, X = get_test_problem(task='classification')
 
     fm = als.FMClassification(n_iter=1000,
-            init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
     fm.fit(X, y)
     y_pred = fm.predict(X)
     print(y_pred)
     assert metrics.accuracy_score(y, y_pred) > 0.95
     # check different size
-    fm.fit(X[:2,], y[:2])
+    fm.fit(X[:2, ], y[:2])
 
 
 def test_als_warm_start():
@@ -140,7 +140,7 @@ def test_warm_start_path():
     l2_reg_V = 0
 
     fm = als.FMRegression(n_iter=0, l2_reg_w=l2_reg_w,
-            l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
+                          l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
     # initalize coefs
     fm.fit(X_train, y_train)
 
@@ -148,8 +148,10 @@ def test_warm_start_path():
     rmse_test = []
     for i in range(1, n_iter):
         fm.fit(X_train, y_train, n_more_iter=step_size)
-        rmse_train.append(np.sqrt(mean_squared_error(fm.predict(X_train), y_train)))
-        rmse_test.append(np.sqrt(mean_squared_error(fm.predict(X_test), y_test)))
+        rmse_train.append(np.sqrt(mean_squared_error(
+            fm.predict(X_train), y_train)))
+        rmse_test.append(np.sqrt(mean_squared_error(
+            fm.predict(X_test), y_test)))
 
     print('------- restart ----------')
     values = np.arange(1, n_iter)
@@ -157,15 +159,17 @@ def test_warm_start_path():
     rmse_train_re = []
     for i in values:
         fm = als.FMRegression(n_iter=i, l2_reg_w=l2_reg_w,
-                l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
+                              l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
         fm.fit(X_train, y_train)
-        rmse_test_re.append(np.sqrt(mean_squared_error(fm.predict(X_test), y_test)))
-        rmse_train_re.append(np.sqrt(mean_squared_error(fm.predict(X_train), y_train)))
+        rmse_test_re.append(np.sqrt(mean_squared_error(
+            fm.predict(X_test), y_test)))
+        rmse_train_re.append(np.sqrt(mean_squared_error(
+            fm.predict(X_train), y_train)))
 
     assert_almost_equal(rmse_train, rmse_train_re)
     assert_almost_equal(rmse_test, rmse_test_re)
 
 
 if __name__ == '__main__':
-    #test_fm_regression_only_w0()
+    # test_fm_regression_only_w0()
     test_fm_linear_regression()

--- a/fastFM/tests/test_base.py
+++ b/fastFM/tests/test_base.py
@@ -29,7 +29,7 @@ def test_fm_classification_predict_proba():
     w0, w, V, y, X = get_test_problem(task='classification')
 
     fm = als.FMClassification(n_iter=1000,
-            init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
     fm.fit(X, y)
     y_pred = fm.predict(X)
     y_pred = fm.predict_proba(X)

--- a/fastFM/tests/test_datasets.py
+++ b/fastFM/tests/test_datasets.py
@@ -14,7 +14,8 @@ def test_make_user_item_regression():
         X, y, test_size=0.33, random_state=42)
 
     fm = FMRegression(rank=2)
-    y_pred = fm.fit_predict(sp.csc_matrix(X_train), y_train, sp.csc_matrix(X_test))
+    y_pred = fm.fit_predict(sp.csc_matrix(X_train),
+                            y_train, sp.csc_matrix(X_test))
 
     # generate data with noisy lables
     X, y, coef = make_user_item_regression(label_stdev=2)
@@ -23,6 +24,7 @@ def test_make_user_item_regression():
         X, y, test_size=0.33, random_state=42)
 
     fm = FMRegression(rank=2)
-    y_pred_noise = fm.fit_predict(sp.csc_matrix(X_train), y_train, sp.csc_matrix(X_test))
+    y_pred_noise = fm.fit_predict(sp.csc_matrix(X_train),
+                                  y_train, sp.csc_matrix(X_test))
     assert mean_squared_error(y_pred_noise, y_test) > \
         mean_squared_error(y_pred, y_test)

--- a/fastFM/tests/test_ffm.py
+++ b/fastFM/tests/test_ffm.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import scipy.sparse as sp
-from sklearn.metrics import mean_squared_error, r2_score
 from numpy.testing import assert_almost_equal, assert_equal
 import ffm
 

--- a/fastFM/tests/test_ffm.py
+++ b/fastFM/tests/test_ffm.py
@@ -7,6 +7,7 @@ from sklearn.metrics import mean_squared_error, r2_score
 from numpy.testing import assert_almost_equal, assert_equal
 import ffm
 
+
 def get_test_problem():
     X = sp.csc_matrix(np.array([[6, 1],
                                 [2, 3],
@@ -20,9 +21,11 @@ def get_test_problem():
     w0 = 2
     return w0, w, V, y, X
 
+
 def test_cxsparse_integration():
-    X = sp.csc_matrix(np.arange(60, dtype=np.float64).reshape(6,10))
+    X = sp.csc_matrix(np.arange(60, dtype=np.float64).reshape(6, 10))
     assert_almost_equal(ffm.cs_norm(X), X.sum(axis=0).max())
+
 
 def test_ffm_predict():
     w0, w, V, y, X = get_test_problem()

--- a/fastFM/tests/test_mcmc.py
+++ b/fastFM/tests/test_mcmc.py
@@ -49,7 +49,7 @@ def test_fm_classification():
     fpr, tpr, thresholds = metrics.roc_curve(y_labels, y_pred)
     auc = metrics.auc(fpr, tpr)
     assert auc > 0.95
-    y_pred = fm.predict(X[:2,])
+    y_pred = fm.predict(X[:2, ])
 
 
 def test_linear_fm_classification():
@@ -64,7 +64,7 @@ def test_linear_fm_classification():
     fpr, tpr, thresholds = metrics.roc_curve(y_labels, y_pred)
     auc = metrics.auc(fpr, tpr)
     assert auc > 0.95
-    y_pred = fm.predict(X[:2,])
+    y_pred = fm.predict(X[:2, ])
 
 
 def test_fm_classification_proba():
@@ -114,12 +114,15 @@ def test_find_init_stdev():
 
     fm = mcmc.FMRegression(n_iter=10, rank=5)
     best_init_stdev, mse = mcmc.find_init_stdev(fm, X_train, y_train,
-            stdev_range=[0.2, 0.5, 1.0])
+                                                stdev_range=[0.2, 0.5, 1.0])
     best_init_stdev_bad, _ = mcmc.find_init_stdev(fm, X_train, y_train,
-        stdev_range=[5.])
+                                                  stdev_range=[5.])
     print('--' * 30)
-    best_init_stdev_vali, mse_vali = mcmc.find_init_stdev(fm, X_train, y_train, X_test,
-            y_test, stdev_range=[0.2, 0.5, 1.0])
+    best_init_stdev_vali, mse_vali = mcmc.find_init_stdev(fm,
+                                                          X_train, y_train,
+                                                          X_test, y_test,
+                                                          stdev_range=[
+                                                              0.2, 0.5, 1.0])
     assert best_init_stdev < best_init_stdev_bad
     assert best_init_stdev_vali == best_init_stdev
     assert mse_vali > mse

--- a/fastFM/tests/test_ranking.py
+++ b/fastFM/tests/test_ranking.py
@@ -24,6 +24,7 @@ def get_test_problem(task='regression'):
         y = y_labels
     return w0, w, V, y, X
 
+
 def test_fm_sgr_ranking():
     w0, w, V, y, X = get_test_problem()
     X_test = X.copy()
@@ -43,8 +44,8 @@ def test_fm_sgr_ranking():
 
     print(compares)
     fm = bpr.FMRecommender(n_iter=2000,
-            init_stdev=0.01, l2_reg_w=.5, l2_reg_V=.5, rank=2,
-            step_size=.002, random_state=11)
+                           init_stdev=0.01, l2_reg_w=.5, l2_reg_V=.5, rank=2,
+                           step_size=.002, random_state=11)
     fm.fit(X_train, compares)
     y_pred = fm.predict(X_test)
     y_pred = np.argsort(y_pred)
@@ -52,4 +53,3 @@ def test_fm_sgr_ranking():
     print(y_pred)
     print(np.argsort(y))
     assert utils.kendall_tau(np.argsort(y), y_pred) == 1
-

--- a/fastFM/tests/test_sgd.py
+++ b/fastFM/tests/test_sgd.py
@@ -31,8 +31,8 @@ def test_fm_sgd_regression():
     X_train = sp.csc_matrix(X)
 
     fm = sgd.FMRegression(n_iter=10000,
-            init_stdev=0.01, l2_reg_w=0.5, l2_reg_V=50.5, rank=2,
-            step_size=0.0001)
+                          init_stdev=0.01, l2_reg_w=0.5, l2_reg_V=50.5, rank=2,
+                          step_size=0.0001)
 
     fm.fit(X_train, y)
     y_pred = fm.predict(X_test)
@@ -45,13 +45,14 @@ def test_fm_sgd_classification():
     X_train = sp.csc_matrix(X)
 
     fm = sgd.FMClassification(n_iter=1000,
-            init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2, step_size=0.1)
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2,
+                              step_size=0.1)
     fm.fit(X_train, y)
     y_pred = fm.predict(X_test)
     print(y_pred)
     assert metrics.accuracy_score(y, y_pred) > 0.95
 
 
-if __name__== '__main__':
+if __name__ == '__main__':
 
     test_fm_sgd_regression()

--- a/fastFM/tests/test_utils.py
+++ b/fastFM/tests/test_utils.py
@@ -4,13 +4,14 @@
 import numpy as np
 from fastFM.utils import kendall_tau
 
+
 def test_ffm_vector_kendall_tau():
     order = np.array([1, 2, 3, 4, 5])
     order_wrong = np.array([5, 3, 4, 2, 1])
     order_inv = np.array([5, 4, 3, 2, 1])
 
     assert kendall_tau(order, order) == 1
-    assert kendall_tau(order, order_inv) ==  -1
+    assert kendall_tau(order, order_inv) == -1
     assert kendall_tau(order, order_wrong) != -1
 
 

--- a/fastFM/validation.py
+++ b/fastFM/validation.py
@@ -96,8 +96,8 @@ def assert_all_finite(X):
     # First try an O(n) time, O(1) space solution for the common case that
     # everything is finite; fall back to O(n) space np.isfinite to prevent
     # false positives from overflow in sum method.
-    if (X.dtype.char in np.typecodes['AllFloat'] and not np.isfinite(X.sum())
-            and not np.isfinite(X).all()):
+    if (X.dtype.char in np.typecodes['AllFloat'] and
+            not np.isfinite(X.sum()) and not np.isfinite(X).all()):
         raise ValueError("Input contains NaN, infinity"
                          " or a value too large for %r." % X.dtype)
 
@@ -162,7 +162,8 @@ def check_array(array, accept_sparse=None, dtype="numeric", order=None,
         if ensure_2d:
             array = np.atleast_2d(array)
         if dtype_numeric:
-            if hasattr(array, "dtype") and getattr(array.dtype, "kind", None) == "O":
+            if (hasattr(array, "dtype") and
+                    getattr(array.dtype, "kind", None) == "O"):
                 # if input is object, convert to float.
                 dtype = np.float64
             else:


### PR DESCRIPTION
As you know, Python has an official coding style guide [PEP8](https://www.python.org/dev/peps/pep-0008/). In order to follow PEP8, I have fixed several lines of code under the fastFM/ folder.

```
$ pep8 fastFM                                                                                                                                                                     
fastFM/mcmc.py:12:19: E128 continuation line under-indented for visual indent
fastFM/validation.py:100:13: W503 line break before binary operator
fastFM/validation.py:165:80: E501 line too long (85 > 79 characters)
fastFM/tests/test_als.py:79:25: E231 missing whitespace after ','
fastFM/tests/test_als.py:81:33: E231 missing whitespace after ','
fastFM/tests/test_als.py:88:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_als.py:94:16: E231 missing whitespace after ','
fastFM/tests/test_als.py:143:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_als.py:151:80: E501 line too long (84 > 79 characters)
fastFM/tests/test_als.py:152:80: E501 line too long (81 > 79 characters)
fastFM/tests/test_als.py:160:17: E128 continuation line under-indented for visual indent
fastFM/tests/test_als.py:162:80: E501 line too long (84 > 79 characters)
fastFM/tests/test_als.py:163:80: E501 line too long (87 > 79 characters)
fastFM/tests/test_als.py:170:5: E265 block comment should start with '# '
fastFM/tests/test_base.py:32:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_datasets.py:17:80: E501 line too long (83 > 79 characters)
fastFM/tests/test_datasets.py:26:80: E501 line too long (89 > 79 characters)
fastFM/tests/test_ffm.py:10:1: E302 expected 2 blank lines, found 1
fastFM/tests/test_ffm.py:23:1: E302 expected 2 blank lines, found 1
fastFM/tests/test_ffm.py:24:64: E231 missing whitespace after ','
fastFM/tests/test_ffm.py:27:1: E302 expected 2 blank lines, found 1
fastFM/tests/test_mcmc.py:52:29: E231 missing whitespace after ','
fastFM/tests/test_mcmc.py:67:29: E231 missing whitespace after ','
fastFM/tests/test_mcmc.py:117:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_mcmc.py:119:9: E128 continuation line under-indented for visual indent
fastFM/tests/test_mcmc.py:121:80: E501 line too long (87 > 79 characters)
fastFM/tests/test_mcmc.py:122:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_ranking.py:27:1: E302 expected 2 blank lines, found 1
fastFM/tests/test_ranking.py:46:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_ranking.py:47:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_ranking.py:55:1: W391 blank line at end of file
fastFM/tests/test_sgd.py:34:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_sgd.py:35:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_sgd.py:48:13: E128 continuation line under-indented for visual indent
fastFM/tests/test_sgd.py:55:12: E225 missing whitespace around operator
fastFM/tests/test_utils.py:7:1: E302 expected 2 blank lines, found 1
fastFM/tests/test_utils.py:13:44: E222 multiple spaces after operator
```
