### PR TITLE
Add sgd comments

### DIFF
--- a/fastFM/bpr.py
+++ b/fastFM/bpr.py
@@ -79,11 +79,14 @@ class FMRecommender(FactorizationMachine):
                 the first returns a high value then the second
                 FM(X[i,0]) > FM(X[i, 1]).
         """
-        X = X.T
+        # The sgd solver expects a transposed design matrix in column major
+        # order (csc_matrix).
+        X = X.T  # creates a copy
         X = check_array(X, accept_sparse="csc", dtype=np.float64)
         assert_all_finite(pairs)
 
         pairs = pairs.astype(np.float64)
+
         # check that pairs contain no real values
         assert_array_equal(pairs, pairs.astype(np.int32))
         assert pairs.max() <= X.shape[1]

--- a/fastFM/ffm.pyx
+++ b/fastFM/ffm.pyx
@@ -115,13 +115,19 @@ def ffm_als_fit(fm, X, double[:] y):
 
 
 def ffm_sgd_fit(fm, X, double[:] y):
+    """
+    The sgd solver expects a transposed design matrix in column major order
+    (csc_matrix) Samples are stored in columns, this allows fast sample by
+    sample access.
+    """
     assert X.shape[1] == len(y) # test shapes
     n_features = X.shape[0]
     X_ = CsMatrix(X)
     pt_X = <cffm.cs_di *> PyCapsule_GetPointer(X_, "CsMatrix")
     param = FFMParam(fm)
     pt_param = <cffm.ffm_param *> PyCapsule_GetPointer(param, "FFMParam")
-    #allocate the coefs
+
+    # allocate the coefs
     cdef double w_0 = 0
     cdef np.ndarray[np.float64_t, ndim=1, mode='c'] w =\
          np.zeros(n_features, dtype=np.float64)

--- a/fastFM/sgd.py
+++ b/fastFM/sgd.py
@@ -83,7 +83,10 @@ class FMRegression(FactorizationMachine, RegressorMixin):
 
         check_consistent_length(X, y)
         y = check_array(y, ensure_2d=False, dtype=np.float64)
-        X = X.T
+
+        # The sgd solver expects a transposed design matrix in column major
+        # order (csc_matrix).
+        X = X.T  # creates a copy
         X = check_array(X, accept_sparse="csc", dtype=np.float64)
 
         self.w0_, self.w_, self.V_ = ffm.ffm_sgd_fit(self, X, y)
@@ -176,7 +179,10 @@ class FMClassification(BaseFMClassifier):
 
         check_consistent_length(X, y)
         y = y.astype(np.float64)
-        X = X.T
+
+        # The sgd solver expects a transposed design matrix in column major
+        # order (csc_matrix).
+        X = X.T  # creates a copy
         X = check_array(X, accept_sparse="csc", dtype=np.float64)
 
         self.w0_, self.w_, self.V_ = ffm.ffm_sgd_fit(self, X, y)

--- a/fastFM/tests/test_sgd.py
+++ b/fastFM/tests/test_sgd.py
@@ -63,18 +63,17 @@ def test_second_order_sgd_vs_als_regression():
     X, y = make_regression(n_samples=100, n_features=50, random_state=123)
     X = sp.csc_matrix(X)
 
-    fm_sgd = sgd.FMRegression(n_iter=900, init_stdev=0.01, l2_reg_w=0.0,
-                              l2_reg_V=50.5, rank=2, step_size=0.01)
+    fm_sgd = sgd.FMRegression(n_iter=50000, init_stdev=0.00, l2_reg_w=0.0,
+                              l2_reg_V=50.5, rank=2, step_size=0.0002)
     fm_als = als.FMRegression(n_iter=10, l2_reg_w=0, l2_reg_V=0, rank=2)
 
     y_pred_als = fm_als.fit(X, y).predict(X)
     y_pred_sgd = fm_sgd.fit(X, y).predict(X)
-    print(y_pred_sgd)
 
     score_als = metrics.r2_score(y_pred_als, y)
     score_sgd = metrics.r2_score(y_pred_sgd, y)
 
-    assert_almost_equal(score_als, score_sgd, decimal=2)
+    assert_almost_equal(score_sgd, score_als, decimal=2)
 
 
 def test_sgd_classification_small_example():


### PR DESCRIPTION
* Adding some comments the sgd solver that better explain that fastFM-core expects the transpose of the design matrix in column major order. The conversion is currently done automatically for every fit. A more efficient solution would be nice.
* Add larger test for sgd regression.

#61 