### PR TITLE
Support sklearn's clone method

### DIFF
--- a/fastFM/als.py
+++ b/fastFM/als.py
@@ -62,6 +62,7 @@ class FMRegression(FactorizationMachine, RegressorMixin):
         else:
             self.l2_reg_w = l2_reg_w
             self.l2_reg_V = l2_reg_V
+        self.l2_reg = l2_reg
         self.task = "regression"
 
     def fit(self, X_train, y_train, n_more_iter=0):
@@ -156,6 +157,7 @@ class FMClassification(BaseFMClassifier):
         else:
             self.l2_reg_w = l2_reg_w
             self.l2_reg_V = l2_reg_V
+        self.l2_reg = l2_reg
         self.task = "classification"
 
     def fit(self, X_train, y_train):

--- a/fastFM/sgd.py
+++ b/fastFM/sgd.py
@@ -67,6 +67,7 @@ class FMRegression(FactorizationMachine, RegressorMixin):
         else:
             self.l2_reg_w = l2_reg_w
             self.l2_reg_V = l2_reg_V
+        self.l2_reg = l2_reg
         self.step_size = step_size
         self.task = "regression"
 
@@ -150,6 +151,7 @@ class FMClassification(BaseFMClassifier):
         else:
             self.l2_reg_w = l2_reg_w
             self.l2_reg_V = l2_reg_V
+        self.l2_reg = l2_reg
         self.step_size = step_size
         self.task = "classification"
 

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -169,6 +169,18 @@ def test_warm_start_path():
     assert_almost_equal(rmse_test, rmse_test_re)
 
 
+def test_clone():
+    from sklearn.base import clone
+
+    a = als.FMRegression()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+    a = als.FMClassification()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+
 if __name__ == '__main__':
     # test_fm_regression_only_w0()
     test_fm_linear_regression()

--- a/fastFM/tests/test_mcmc.py
+++ b/fastFM/tests/test_mcmc.py
@@ -128,5 +128,17 @@ def test_find_init_stdev():
     assert mse_vali > mse
 
 
+def test_clone():
+    from sklearn.base import clone
+
+    a = mcmc.FMRegression()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+    a = mcmc.FMClassification()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+
 if __name__ == "__main__":
     test_linear_fm_classification()

--- a/fastFM/tests/test_sgd.py
+++ b/fastFM/tests/test_sgd.py
@@ -90,6 +90,18 @@ def test_sgd_classification_small_example():
     assert metrics.accuracy_score(y, y_pred) > 0.95
 
 
+def test_clone():
+    from sklearn.base import clone
+
+    a = sgd.FMRegression()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+    a = sgd.FMClassification()
+    b = clone(a)
+    assert a.get_params() == b.get_params()
+
+
 if __name__ == '__main__':
     test_sgd_regression_small_example()
     test_first_order_sgd_vs_als_regression()


### PR DESCRIPTION
This PR partially fixes the issue #79. This PR does not fix all the compatibility issues with sklearn API, but, as a starting point, this PR fixes the problem of `__init__` methods of the estimators. As confirmed in newly added tests, now all the estimators can be cloned by `sklearn.base.clone`.