### PR TITLE
Fix the explanation of l2_reg_w and l2_reg_V

### DIFF
--- a/fastFM/als.py
+++ b/fastFM/als.py
@@ -31,10 +31,10 @@ class FMRegression(FactorizationMachine, RegressorMixin):
         The rank of the factorization used for the second order interactions.
 
     l2_reg_w : float
-        L2 penalty weight for pairwise coefficients.
+        L2 penalty weight for linear coefficients.
 
     l2_reg_V : float
-        L2 penalty weight for linear coefficients.
+        L2 penalty weight for pairwise coefficients.
 
     l2_reg : float
         L2 penalty weight for all coefficients (default=0).
@@ -124,10 +124,10 @@ class FMClassification(BaseFMClassifier):
         The rank of the factorization used for the second order interactions.
 
     l2_reg_w : float
-        L2 penalty weight for pairwise coefficients.
+        L2 penalty weight for linear coefficients.
 
     l2_reg_V : float
-        L2 penalty weight for linear coefficients.
+        L2 penalty weight for pairwise coefficients.
 
     l2_reg : float
         L2 penalty weight for all coefficients (default=0).

--- a/fastFM/bpr.py
+++ b/fastFM/bpr.py
@@ -28,10 +28,10 @@ class FMRecommender(FactorizationMachine):
         The rank of the factorization used for the second order interactions.
 
     l2_reg_w : float
-        L2 penalty weight for pairwise coefficients.
+        L2 penalty weight for linear coefficients.
 
     l2_reg_V : float
-        L2 penalty weight for linear coefficients.
+        L2 penalty weight for pairwise coefficients.
 
     l2_reg : float
         L2 penalty weight for all coefficients (default=0).

--- a/fastFM/sgd.py
+++ b/fastFM/sgd.py
@@ -31,10 +31,10 @@ class FMRegression(FactorizationMachine, RegressorMixin):
         The rank of the factorization used for the second order interactions.
 
     l2_reg_w : float
-        L2 penalty weight for pairwise coefficients.
+        L2 penalty weight for linear coefficients.
 
     l2_reg_V : float
-        L2 penalty weight for linear coefficients.
+        L2 penalty weight for pairwise coefficients.
 
     l2_reg : float
         L2 penalty weight for all coefficients (default=0).
@@ -114,10 +114,10 @@ class FMClassification(BaseFMClassifier):
         The rank of the factorization used for the second order interactions.
 
     l2_reg_w : float
-        L2 penalty weight for pairwise coefficients.
+        L2 penalty weight for linear coefficients.
 
     l2_reg_V : float
-        L2 penalty weight for linear coefficients.
+        L2 penalty weight for pairwise coefficients.
 
     l2_reg : float
         L2 penalty weight for all coefficients (default=0).


### PR DESCRIPTION
I'm not very confident, but I think `w` and `V` are linear and pairwise coefficients, respectively, and so, `l2_reg_w` and `l2_reg_V` should be penalty weights for linear and pairwise coefficients.

Currently, the explanations of them seem wrongly swapped. This PR proposes to fix them.