### PR TITLE
Replace sklearn deprecated cross_validation module

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -56,7 +56,7 @@ efficiently. Please note that we can replace them with any metric we want.
     import numpy as np
 
     X, y, coef = make_user_item_regression(label_stdev=.4)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
 
@@ -114,7 +114,7 @@ model parameter efficiently using the `warm_start` option.
 
     import numpy as np
     from sklearn.metrics import mean_squared_error
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
 
     from fastFM.datasets import make_user_item_regression
     from fastFM import mcmc

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -17,7 +17,7 @@ refere to [SIGIR2011] for background information on the implemented ALS solver.
 .. testcode::
 
     from fastFM.datasets import make_user_item_regression
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
 
     # This sets up a small test dataset.
     X, y, _ = make_user_item_regression(label_stdev=.4)

--- a/fastFM/datasets.py
+++ b/fastFM/datasets.py
@@ -43,7 +43,7 @@ def make_user_item_regression(random_state=123, n_user=20, n_item=20,
 if __name__ == '__main__':
     X, y, coef = make_user_item_regression(n_user=5, n_item=5, rank=2,
                                            label_stdev=2)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
 

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -95,7 +95,7 @@ def test_fm_classification():
 
 def test_als_warm_start():
     X, y, coef = make_user_item_regression(label_stdev=0)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
     X_train = sp.csc_matrix(X_train)
@@ -125,7 +125,7 @@ def test_als_warm_start():
 def test_warm_start_path():
 
     X, y, coef = make_user_item_regression(label_stdev=.4)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
     X_train = sp.csc_matrix(X_train)

--- a/fastFM/tests/test_datasets.py
+++ b/fastFM/tests/test_datasets.py
@@ -9,7 +9,7 @@ import scipy.sparse as sp
 def test_make_user_item_regression():
     from fastFM.mcmc import FMRegression
     X, y, coef = make_user_item_regression(label_stdev=0)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
 
@@ -19,7 +19,7 @@ def test_make_user_item_regression():
 
     # generate data with noisy lables
     X, y, coef = make_user_item_regression(label_stdev=2)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=42)
 

--- a/fastFM/tests/test_mcmc.py
+++ b/fastFM/tests/test_mcmc.py
@@ -83,7 +83,7 @@ def test_fm_classification_proba():
 
 def test_mcmc_warm_start():
     X, y, coef = make_user_item_regression(label_stdev=0)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=44)
     X_train = sp.csc_matrix(X_train)
@@ -106,7 +106,7 @@ def test_mcmc_warm_start():
 
 def test_find_init_stdev():
     X, y, coef = make_user_item_regression(label_stdev=.5)
-    from sklearn.cross_validation import train_test_split
+    from sklearn.model_selection import train_test_split
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.33, random_state=44)
     X_train = sp.csc_matrix(X_train)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Cython>=0.22
 numpy>=1.9.1
 scipy>=0.15.1
-scikit-learn>=0.14.0
+scikit-learn>=0.18.0


### PR DESCRIPTION
`$ nosetests fastFM/tests` said the following warning message:

````
/path/to/sklearn/cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)
````

This message can also be seen in the past travis log e.g., https://travis-ci.org/ibayer/fastFM/jobs/179204914#L983

As the message says, the `sklearn.cross_validation` module is grouped into a new `sklearn.model_selection` module from version 0.18. See the release note from [HERE](http://scikit-learn.org/stable/whats_new.html#version-0-18). Hence, I updated the minimum required version of the scikit-learn library and fixed corresponding import statements both in code and documents.

Note that `examples/warm_start_als.py` and `examples/warm_start_mcmc.py` are also using the `cross_validation` module, but I did not touch the code because the examples directory does not seem to be maintained.