### PR TITLE
update fastFM-core to include static linking of openblas

### DIFF
--- a/fastFM/cffm.pxd
+++ b/fastFM/cffm.pxd
@@ -11,8 +11,6 @@ cdef extern from "../fastFM-core/externals/CXSparse/Include/cs.h":
         double *x      # numerical values, size nzmax */
         int nz         # # of entries in triplet matrix, -1 for compressed-col */
 
-    double cs_di_norm(const cs_di *X) # max colsum
-
 cdef extern from "../fastFM-core/include/ffm.h":
 
     ctypedef struct ffm_param:

--- a/fastFM/ffm.pyx
+++ b/fastFM/ffm.pyx
@@ -209,9 +209,3 @@ def ffm_mcmc_fit_predict(fm, X_train, X_test, double[:] y):
                               pt_param)
     fm.hyper_param_ = hyper_param
     return (w_0, w, V), y_pred
-
-
-def cs_norm(X):
-    X = CsMatrix(X)
-    pt = <cffm.cs_di *> PyCapsule_GetPointer(X, "CsMatrix")
-    return cffm.cs_di_norm(pt)

--- a/fastFM/tests/test_ffm.py
+++ b/fastFM/tests/test_ffm.py
@@ -21,11 +21,6 @@ def get_test_problem():
     return w0, w, V, y, X
 
 
-def test_cxsparse_integration():
-    X = sp.csc_matrix(np.arange(60, dtype=np.float64).reshape(6, 10))
-    assert_almost_equal(ffm.cs_norm(X), X.sum(axis=0).max())
-
-
 def test_ffm_predict():
     w0, w, V, y, X = get_test_problem()
     y_pred = ffm.ffm_predict(w0, w, V, X)

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ import numpy
 
 ext_modules = [
     Extension('ffm', ['fastFM/ffm.pyx'],
-              libraries=['m', 'fastfm', 'cxsparse', 'blas'],
-              library_dirs=['fastFM/', 'fastFM-core/bin/',
-                            'fastFM-core/externals/CXSparse/Lib/'],
+              libraries=['m', 'fastfm'],
+              library_dirs=['fastFM/', 'fastFM-core/bin/'],
               include_dirs=['fastFM/', 'fastFM-core/include/',
                             'fastFM-core/externals/CXSparse/Include/',
               numpy.get_include()])]


### PR DESCRIPTION
This PR replaces https://github.com/ibayer/fastFM/pull/89