### PR TITLE
fastFM builds with only Python 3 available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	( cd fastFM-core ; $(MAKE) lib )
-	python setup.py build_ext --inplace
+	python setup.py build_ext --inplace || python3 setup.py build_ext --inplace
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
With this simple addition one can also build the module on a system with only Python 3 installed.
