### PR TITLE
add n_more_iter option to `als.FMClassification.fit`

### DIFF
--- a/fastFM/als.py
+++ b/fastFM/als.py
@@ -160,7 +160,7 @@ class FMClassification(BaseFMClassifier):
         self.l2_reg = l2_reg
         self.task = "classification"
 
-    def fit(self, X_train, y_train):
+    def fit(self, X_train, y_train, n_more_iter=0):
         """ Fit model with specified loss.
 
         Parameters
@@ -169,6 +169,9 @@ class FMClassification(BaseFMClassifier):
 
         y : float | ndarray, shape = (n_samples, )
                 the targets have to be encodes as {-1, 1}.
+        
+        n_more_iter : int
+                Number of iterations to continue from the current Coefficients.
         """
         check_consistent_length(X_train, y_train)
         X_train = check_array(X_train, accept_sparse="csc", dtype=np.float64,
@@ -187,5 +190,19 @@ class FMClassification(BaseFMClassifier):
         y_train[i_class1] = -1
         y_train[~i_class1] = 1
 
+        self.n_iter = self.n_iter + n_more_iter
+
+        if n_more_iter > 0:
+            _check_warm_start(self, X_train)
+            self.warm_start = True
+
         self.w0_, self.w_, self.V_ = ffm.ffm_als_fit(self, X_train, y_train)
+
+        if self.iter_count != 0:
+            self.iter_count = self.iter_count + n_more_iter
+        else:
+            self.iter_count = self.n_iter
+
+        # reset to default setting
+        self.warm_start = False
         return self

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -169,6 +169,36 @@ def test_warm_start_path():
     assert_almost_equal(rmse_test, rmse_test_re)
 
 
+def test_als_classification_warm_start():
+    w0, w, V, y, X = get_test_problem(task='classification')
+
+    # 10 iter
+    fm = als.FMClassification(n_iter=10,
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
+    fm.fit(X, y)
+    y_pred = fm.predict(X)
+    score = metrics.accuracy_score(y, y_pred)
+
+    # 5 iter + 5 more iter
+    fm = als.FMClassification(n_iter=5,
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
+    fm.fit(X, y)
+    fm.fit(X, y, n_more_iter=5)
+    y_pred = fm.predict(X)
+    score_warm_start = metrics.accuracy_score(y, y_pred)
+
+    # 0 iter + 10 more iter
+    fm = als.FMClassification(n_iter=0,
+                              init_stdev=0.1, l2_reg_w=0, l2_reg_V=0, rank=2)
+    fm.fit(X, y)
+    fm.fit(X, y, n_more_iter=10)
+    y_pred = fm.predict(X)
+    score_warm_start_2 = metrics.accuracy_score(y, y_pred)
+
+    assert_almost_equal(score, score_warm_start)
+    assert_almost_equal(score, score_warm_start_2)
+
+
 def test_clone():
     from sklearn.base import clone
 


### PR DESCRIPTION
I added `n_more_iter` option to `als.FMClassification.fit` just like `als.FMRegression.fit`.

I don't know if there is any theoretical incompatibility between classification problem and warm start and can't confirm due to this problem https://github.com/ibayer/fastFM-core/issues/25 .

If there is no incompatibility, please merge it.