### PR TITLE
Add Cython dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy', 'scikit-learn', 'scipy']
+    install_requires=['numpy', 'scikit-learn', 'scipy', 'cython']
 )


### PR DESCRIPTION
Fix #114 

I guess the reason why test skips this issue is the travis test based on anaconda which includes Cython and numpy.