### PR TITLE
Add Python 3.6 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 
 env:
     - TRAVIS_PYTHON_VERSION="2.7"
-    - TRAVIS_PYTHON_VERSION="3.4"
     - TRAVIS_PYTHON_VERSION="3.5"
     - TRAVIS_PYTHON_VERSION="3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
     - TRAVIS_PYTHON_VERSION="2.7"
     - TRAVIS_PYTHON_VERSION="3.4"
     - TRAVIS_PYTHON_VERSION="3.5"
+    - TRAVIS_PYTHON_VERSION="3.6"
 
 os:
     - linux

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # List run-time dependencies here.  These will be installed by pip when


### PR DESCRIPTION
Since Python 3.6 is becoming popular, I will add Python 3.6 test, which also introduces .whl file.

I removed 3.4 test at the same time, but I can revert the commit if you'd like to keep maintenance 3.4.