### PR TITLE
Cython wrapper build fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/ibayer/fastFM-core.git
 [submodule "fastFM-core2"]
 	path = fastFM-core2
-	url = git@github.com:AlexJoz/fastFM-core2.git
+	url = git@github.com:ibayer/fastFM-core2.git
     branch = api

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/ibayer/fastFM-core.git
 [submodule "fastFM-core2"]
 	path = fastFM-core2
-	url = git@github.com:ibayer/fastFM-core2.git
+	url = git@github.com:AlexJoz/fastFM-core2.git
     branch = api

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 env:
+  global:
     - TRAVIS_PYTHON_VERSION="2.7"
     - TRAVIS_PYTHON_VERSION="3.4"
     - TRAVIS_PYTHON_VERSION="3.5"
@@ -11,7 +12,11 @@ os:
 
 dist: trusty
 
+git:
+    submodules: false
+
 before_install:
+
       # fastFM-core depends on cblas
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libopenblas-dev; fi
     - if [[ "$TRAVIS_PYTHON_VERSION" =~ "^2" ]]; then
@@ -37,8 +42,16 @@ before_install:
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cython numpy pandas scipy scikit-learn nose
     - source activate test-environment
 
+    # use credentials
+    - sed -i -e "s|git@github.com:|https://$CI_USER:$CI_PASS@github.com/|" .gitmodules
+
+
 install:
     - git submodule update --init --recursive
+    - cd fastFM-core2
+    - cmake -H. -B_builds -DCMAKE_BUILD_TYPE=Debug -DFASTFM_MINIMAL=ON
+    - cmake --build cmake-build-debug
+    - cd ..
     - make
     - python setup.py bdist_wheel
     - pip install dist/*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - source activate test-environment
 
     # use credentials
-    - sed -i -e "s|git@github.com:|https://$CI_USER:$CI_PASS@github.com/|" .gitmodules
+    - sed -i -e "s|git@github.com:|https://$CI_USER_NAME:$CI_USER_PASSWORD@github.com/|" .gitmodules
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     - source activate test-environment
 
     # use credentials
-    - sed -i -e "s|git@github.com:|https://$CI_USER_NAME:$CI_USER_PASSWORD@github.com/|" .gitmodules
+    - sed -i -e "s|git@github.com:|https://$CI_TOKEN@github.com/|" .gitmodules
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 install:
     - git submodule update --init --recursive
     - cd fastFM-core2
-    - cmake -H. -B_builds -DCMAKE_BUILD_TYPE=Debug -DFASTFM_MINIMAL=ON
+    - cmake -H. -Bcmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DFASTFM_MINIMAL=ON
     - cmake --build cmake-build-debug
     - cd ..
     - make


### PR DESCRIPTION
Hello. 
Seems user keys works only for private root repos, so I managed to make it work with user credentials encrypted via travis. Is it possible to make the [dedicated user](https://docs.travis-ci.com/user/private-dependencies/#Dedicated-User-Account) for that purpose?

And the second question, why shouldn't we use Hunter? Maybe we can add eigen via ExternalProject_Add in cmake or smth similar specially for travis build, but does it worth it? Or you just want to cut out Hunter away?