### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,7 @@ A short paper describing the library is available on arXiv http://arxiv.org/abs/
 
 Supported Operating Systems
 ---------------------------
-fastFM has a continous integration / testing servers (Travis) for **Linux (Ubuntu 14.04 LTS)**
+fastFM has a continuous integration / testing servers (Travis) for **Linux (Ubuntu 14.04 LTS)**
 and **OS X Mavericks**. Other OS are not actively supported.
 
 .. toctree::

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -12,7 +12,7 @@ Regression with ALS Solver
 --------------------------
 
 We first set up a small toy dataset for a regression problem. Please
-refere to [SIGIR2011] for background information on the implemented ALS solver.
+refer to [SIGIR2011] for background information on the implemented ALS solver.
 
 .. testcode::
 

--- a/examples/warm_start_als.py
+++ b/examples/warm_start_als.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     fm = als.FMRegression(n_iter=0, l2_reg_w=l2_reg_w,
             l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
-    # initalize coefs
+    # initialize coefs
     fm.fit(X_train, y_train)
 
     rmse_train = []

--- a/examples/warm_start_mcmc.py
+++ b/examples/warm_start_mcmc.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     """
 
     fm = mcmc.FMRegression(n_iter=0, rank=rank, random_state=seed)
-    # initalize coefs
+    # initialize coefs
     fm.fit_predict(X_train, y_train, X_test)
 
     rmse_test = []

--- a/fastFM/bpr.py
+++ b/fastFM/bpr.py
@@ -38,7 +38,7 @@ class FMRecommender(FactorizationMachine):
 
     step_size : float
         Stepsize for the SGD solver, the solver uses a fixed step size and
-        might require a tunning of the number of iterations `n_iter`.
+        might require a tuning of the number of iterations `n_iter`.
 
     Attributes
     ---------

--- a/fastFM/sgd.py
+++ b/fastFM/sgd.py
@@ -41,7 +41,7 @@ class FMRegression(FactorizationMachine, RegressorMixin):
 
     step_size : float
         Stepsize for the SGD solver, the solver uses a fixed step size and
-        might require a tunning of the number of iterations `n_iter`.
+        might require a tuning of the number of iterations `n_iter`.
 
     Attributes
     ---------
@@ -125,7 +125,7 @@ class FMClassification(BaseFMClassifier):
 
     step_size : float
         Stepsize for the SGD solver, the solver uses a fixed step size and
-        might require a tunning of the number of iterations `n_iter`.
+        might require a tuning of the number of iterations `n_iter`.
 
     Attributes
     ---------

--- a/fastFM/tests/test_als.py
+++ b/fastFM/tests/test_als.py
@@ -140,7 +140,7 @@ def test_warm_start_path():
 
     fm = als.FMRegression(n_iter=0, l2_reg_w=l2_reg_w,
                           l2_reg_V=l2_reg_V, rank=rank, random_state=seed)
-    # initalize coefs
+    # initialize coefs
     fm.fit(X_train, y_train)
 
     rmse_train = []

--- a/fastFM/validation.py
+++ b/fastFM/validation.py
@@ -217,7 +217,7 @@ def check_random_state(seed):
 
 
 def _shape_repr(shape):
-    """Return a platform independent reprensentation of an array shape
+    """Return a platform independent representation of an array shape
     Under Python 2, the `long` type introduces an 'L' suffix when using the
     default %r format for tuples of integers (typically used to store the shape
     of an array).


### PR DESCRIPTION
There are small typos in:
- doc/index.rst
- doc/tutorial.rst
- examples/warm_start_als.py
- examples/warm_start_mcmc.py
- fastFM/bpr.py
- fastFM/sgd.py
- fastFM/tests/test_als.py
- fastFM/validation.py

Fixes:
- Should read `tuning` rather than `tunning`.
- Should read `initialize` rather than `initalize`.
- Should read `representation` rather than `reprensentation`.
- Should read `refer` rather than `refere`.
- Should read `continuous` rather than `continous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md